### PR TITLE
feat: disable php auto format

### DIFF
--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -1,0 +1,20 @@
+return {
+  "stevearc/conform.nvim",
+  opts = function(_, opts)
+    opts.format_on_save = function(bufnr)
+      if vim.bo[bufnr].filetype == "php" then
+        return false
+      end
+      return { timeout_ms = 500, lsp_fallback = true }
+    end
+  end,
+  keys = {
+    {
+      "<leader>cp",
+      function()
+        require("conform").format({ async = true, lsp_fallback = true })
+      end,
+      desc = "Format with Prettier",
+    },
+  },
+}

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -1,18 +1,18 @@
 return {
   "stevearc/conform.nvim",
-  opts = function(_, opts)
-    opts.format_on_save = function(bufnr)
-      if vim.bo[bufnr].filetype == "php" then
-        return false
-      end
-      return { timeout_ms = 500, lsp_fallback = true }
-    end
+  init = function()
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "php",
+      callback = function()
+        vim.b.autoformat = false
+      end,
+    })
   end,
   keys = {
     {
       "<leader>cp",
       function()
-        require("conform").format({ async = true, lsp_fallback = true })
+        require("conform").format({ async = true, lsp_fallback = true, formatters = { "prettier" } })
       end,
       desc = "Format with Prettier",
     },


### PR DESCRIPTION
## Summary
- avoid running Prettier when saving PHP files
- add hotkey to run Prettier on demand

## Testing
- `stylua lua/plugins/conform.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6890bdc994608326bf65fe3cbd91aaae